### PR TITLE
Fall back to _version.py when setuptools_scm is unavailable at build time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,43 @@
+import os
 from glob import glob
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
+
+
+def _version_kwarg():
+    """Supply a static ``version`` only when setuptools_scm is unavailable.
+
+    setuptools_scm is the source of truth for the version: it derives it from
+    git tags (or from PKG-INFO when building an sdist) and writes
+    danish/_version.py. When it's installed we pass nothing here and let its
+    setuptools plugin set the metadata version -- passing ``version`` ourselves
+    would suppress that (setuptools_scm skips a version that is "already set").
+
+    But if setuptools_scm isn't importable at build time it never runs, and
+    setuptools would otherwise stamp the metadata version as "0.0.0". This is
+    exactly the conda-forge build: it disables pip's build isolation and omits
+    setuptools_scm from the recipe's host requirements, so the conda package's
+    recorded version (importlib.metadata / pip show) comes out "0.0.0" even
+    though danish/_version.py is correct. The sdist always ships
+    danish/_version.py, so in that case read the version back from it.
+    """
+    try:
+        import setuptools_scm  # noqa: F401
+    except ImportError:
+        return {"version": _version_from_file()}
+    return {}
+
+
+def _version_from_file():
+    version_file = os.path.join(os.path.dirname(__file__), "danish", "_version.py")
+    namespace = {}
+    try:
+        with open(version_file) as f:
+            exec(f.read(), namespace)
+        return namespace["__version__"]
+    except (OSError, KeyError):
+        return "0.0.0"
+
 
 ext_modules = [
     Pybind11Extension(
@@ -10,6 +47,7 @@ ext_modules = [
 ]
 
 setup(
+    **_version_kwarg(),
     ext_modules=ext_modules,
     cmdclass={"build_ext": build_ext},
 )

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,20 @@ def _version_kwarg():
 
 
 def _version_from_file():
+    import ast
+
     version_file = os.path.join(os.path.dirname(__file__), "danish", "_version.py")
-    namespace = {}
     try:
         with open(version_file) as f:
-            exec(f.read(), namespace)
-        return namespace["__version__"]
-    except (OSError, KeyError):
+            tree = ast.parse(f.read())
+    except OSError:
         return "0.0.0"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    return "0.0.0"
 
 
 ext_modules = [


### PR DESCRIPTION
## Problem

The version is fully dynamic via setuptools_scm (`dynamic = ["version"]` + `write_to = "danish/_version.py"`). When a build environment doesn't have setuptools_scm available, setuptools can't resolve the dynamic version and stamps the wheel metadata as `0.0.0` — even though the sdist ships a correct `danish/_version.py`.

This is exactly what the conda-forge build does: it disables pip's build isolation and (until [conda-forge/danish-feedstock#17](https://github.com/conda-forge/danish-feedstock/pull/17)) omitted setuptools_scm from the recipe's `host` requirements. The result is a conda package where:

```python
>>> import danish; danish.__version__
'1.2.0'                                          # correct (read from shipped _version.py)
>>> import importlib.metadata
>>> importlib.metadata.version("danish")
'0.0.0'                                          # wrong — comes from the wheel METADATA
```

So `pip show danish`, `importlib.metadata.version(...)` and the conda-recorded version all report `0.0.0`.

## Fix

Make the source build robust regardless of the build environment. In `setup.py`:

- If setuptools_scm **can't** be imported, read the version back from the shipped `danish/_version.py` and pass it as `version=`.
- If setuptools_scm **is** present, pass nothing and let its setuptools plugin set the version (git tag / sdist `PKG-INFO`) and regenerate `_version.py`. Passing `version=` ourselves would suppress the plugin — setuptools_scm skips a version that is "already set".

setuptools_scm remains the single source of truth on every normal path (git checkout, `pip install`, sdist build with build isolation); the fallback only kicks in when it's genuinely absent.

## Validation

Reproduced and verified the full matrix by building the sdist and resolving the metadata version:

| build environment | before | after |
| --- | --- | --- |
| git checkout, setuptools_scm present (normal `pip install`) | correct | correct (`_version.py` regenerated) |
| sdist build, setuptools_scm present | correct | correct (from `PKG-INFO`) |
| **sdist build, setuptools_scm absent (conda-forge)** | **`0.0.0`** | **correct (from shipped `_version.py`)** |
| bare checkout, no scm, no `_version.py` | `0.0.0` | `0.0.0` (graceful; not a real dist path) |

End-to-end: `pip install --no-build-isolation` of the sdist into an environment without setuptools_scm now yields `importlib.metadata.version("danish") == "1.2.0"` (was `0.0.0`).

This is complementary to the feedstock fix: the feedstock change repairs the already-published conda package, and this makes future sdists correct in any scm-less build context (conda-forge, Spack, downstream repackagers, `--no-build-isolation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)